### PR TITLE
Ubuntu: install zsh before chsh in set-shell script

### DIFF
--- a/home/.chezmoiscripts/10-ubuntu/run_once_00-set-shell.sh
+++ b/home/.chezmoiscripts/10-ubuntu/run_once_00-set-shell.sh
@@ -1,3 +1,8 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 
+# Ubuntu server defaults to bash and has no zsh. Install it here (this script
+# sorts first by stripped basename) so every subsequent zsh-shebang script in
+# .chezmoiscripts/ can actually execute.
+sudo apt-get update
+sudo apt-get install -y zsh
 chsh -s /usr/bin/zsh


### PR DESCRIPTION
## Summary
- Fresh Ubuntu server has bash but no zsh, so `run_once_00-set-shell.sh` couldn't execute (zsh shebang) and `chsh -s /usr/bin/zsh` targeted a missing binary.
- Switch the script to a bash shebang and `apt-get install -y zsh` before the `chsh`.
- Verified via a scratch chezmoi apply that scripts sort by stripped basename, so `00-set-shell.sh` runs first and zsh is available for every subsequent zsh-shebang script in `.chezmoiscripts/`.

Fixes #4

## Test plan
- [ ] Unable to verify locally (on Arch, not Ubuntu). Will validate on next Ubuntu server bootstrap.